### PR TITLE
Fix language switch option update

### DIFF
--- a/script.js
+++ b/script.js
@@ -148,7 +148,7 @@ function setLanguage(lang) {
                     element.placeholder = data[key];
                 }
                 if (element.tagName === 'SELECT') {
-                    element.options.forEach(option => {
+                    Array.from(element.options).forEach(option => {
                         const optionKey = option.getAttribute('data-key');
                         if (data[optionKey]) {
                             option.textContent = data[optionKey];


### PR DESCRIPTION
## Summary
- prevent error when updating `<select>` options during language switch

## Testing
- `node -e "require('./script.js'); console.log('loaded')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68407875631c83339620b37320f0e48e